### PR TITLE
Avoid using lodash in main to reduce package size

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -8,3 +8,6 @@ src/**
 .gitignore
 tsconfig.json
 vsc-extension-quickstart.md
+package-lock.json
+.yarnclean
+yarn.lock

--- a/.yarnclean
+++ b/.yarnclean
@@ -1,0 +1,42 @@
+# test directories
+__tests__
+test
+tests
+powered-test
+
+# asset directories
+docs
+doc
+website
+images
+assets
+
+# examples
+example
+examples
+
+# code coverage directories
+coverage
+.nyc_output
+
+# build scripts
+Makefile
+Gulpfile.js
+Gruntfile.js
+
+# configs
+.tern-project
+.gitattributes
+.editorconfig
+.*ignore
+.eslintrc
+.jshintrc
+.flowconfig
+.documentup.json
+.yarn-metadata.json
+.*.yml
+*.yml
+
+# misc
+*.gz
+*.md

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
         "async": "^2.1.4",
         "css": "^2.2.1",
         "less": "^2.7.1",
-        "lodash": "^4.17.2",
         "source-map": "^0.5.6",
         "vscode-html-languageservice": "^1.0.0"
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,6 @@
 import * as vscode from 'vscode'
 
 import * as fs   from 'fs'
-import * as _    from 'lodash'
 import {detect}  from 'async'
 import * as css from 'css'
 import * as less from 'less'
@@ -90,7 +89,7 @@ export class PeekCSSDefinitionProvider implements vscode.DefinitionProvider {
    * @return {CompiledCSS} Object containing `css` prop as compiled CSS and `map` prop and sourcemap 
    */
   static async compileCSS(file: string, file_text: string): Promise<CompiledCSS> {
-    switch (_.last(file.split('.'))) {
+    switch ([...(file.split('.'))].pop()) {
       case 'less':
         try {
           const parsed_less: Less.RenderOutput = await less.render(file_text, { filename: file, sourceMap: {} })
@@ -123,7 +122,7 @@ export class PeekCSSDefinitionProvider implements vscode.DefinitionProvider {
     if (!parsed_css.stylesheet.rules) throw new Error('no CSS rules')
 
     const rule: css.Rule = parsed_css.stylesheet.rules.filter((node: css.Node) => node.type === 'rule').find((rule: css.Rule) => {
-      return (_.includes(rule.selectors, selector, 0))
+      return (rule.selectors.includes(selector))
     }) as css.Rule
 
     if (!rule) throw new Error('CSS rule not found in ' + file)
@@ -142,7 +141,7 @@ export class PeekCSSDefinitionProvider implements vscode.DefinitionProvider {
   async findRuleAndMap(selector: {attribute: string, value: string}): Promise<RuleAndMap> {
 
     const file_searches: any = await Promise.all(this.fileSearchExtensions.map(type => vscode.workspace.findFiles(`**/*${type}`, '')))
-    let potential_fnames: string[] = _.flatten(file_searches).map(uri => (uri as any).fsPath)
+    let potential_fnames: string[] = Array.prototype.concat(...file_searches).map(uri => (uri as any).fsPath)
 
     this.exclude
       .map(expression => new RegExp(expression, 'gi'))

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
 		"module": "commonjs",
 		"target": "es6",
 		"outDir": "out",
-		"lib": [ "es6" ],
+		"lib": [ "es7" ],
 		"skipLibCheck": true,
 		"sourceMap": true,
 		"rootDir": "."

--- a/typings.json
+++ b/typings.json
@@ -3,7 +3,6 @@
     "async": "registry:dt/async#2.0.1+20161110083428",
     "css": "registry:dt/css#0.0.0+20151120051005",
     "less": "registry:dt/less#0.0.0+20161208204558",
-    "lodash": "registry:dt/lodash#4.14.0+20161110215204",
     "source-map": "registry:dt/source-map#0.0.0+20161003134342"
   }
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,5 +1,4 @@
 /// <reference path="globals/async/index.d.ts" />
 /// <reference path="globals/css/index.d.ts" />
 /// <reference path="globals/less/index.d.ts" />
-/// <reference path="globals/lodash/index.d.ts" />
 /// <reference path="globals/source-map/index.d.ts" />


### PR DESCRIPTION
This let `vsce package` produced ".vsix" package to reduce about 1MB, unpacked files number reduce about 1k.

I'm not sure it is foolproof, please test it.
<s>Existing directories need to run `yarn clean`.</s>