### PR TITLE
Initial JSX support for class attributes added

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -43,7 +43,11 @@
                         "html",
                         "ejs",
                         "erb",
-                        "php"
+                        "php",
+                        "javascriptreact",
+                        "typescriptreact",
+                        "typescript",
+                        "javascript"
                     ],
                     "items": {
                         "type": "string"

--- a/server/src/core/findSelector.ts
+++ b/server/src/core/findSelector.ts
@@ -44,6 +44,12 @@ export default function findSelector(document: TextDocument, position: Position)
         break;
       case TokenType.AttributeName:
         attribute = htmlScanner.getTokenText().toLowerCase();
+
+        // Convert the attribute to a standard class attribute
+        if (attribute === 'classname') {
+          attribute = 'class';
+        }
+
         break;
       case TokenType.AttributeValue:
         if (attribute === 'class' || attribute === 'id') {


### PR DESCRIPTION
The below set of changes adds simple support for JSX peek through the same mechanism that is already present. This is related to the below issue:

https://github.com/pranaygp/vscode-css-peek/issues/3