### PR TITLE
Update activationEvents to only load when styles are in workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,10 @@
   },
   "homepage": "https://github.com/pranaygp/vscode-css-peek/blob/master/README.md",
   "activationEvents": [
-    "*"
+    "workspaceContains:**/*.css",
+    "workspaceContains:**/*.scss",
+    "workspaceContains:**/*.sass",
+    "workspaceContains:**/*.less"
   ],
   "contributes": {
     "configuration": {


### PR DESCRIPTION
Change `"*"` to `"workspaceContains:**/*.css"`, `"workspaceContains:**/*.scss"`, `"workspaceContains:**/*.sass"`, `"workspaceContains:**/*.less"` to ensure extension only loads when there are relevant files to peek to