### PR TITLE
fix: prevent server process leak (#154)

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -172,16 +172,28 @@ export function activate(context: ExtensionContext): void {
       // Discover stylesheets and read their contents via vscode.workspace.fs
       // (works in virtual/web workspaces). Reads are capped to READ_CONCURRENCY
       // so workspaces with thousands of files don't blow up memory at startup.
-      const gitignoreGlobs = respectGitignore
-        ? await readGitignoreGlobs(folder.uri)
-        : [];
-      const mergedExcludes = Array.from(
-        new Set([...(peekToExclude || []), ...gitignoreGlobs])
-      );
-      const file_searches = await Workspace.findFiles(
-        `{${(peekToInclude || []).join(",")}}`,
-        `{${mergedExcludes.join(",")}}`
-      );
+      let file_searches: Uri[];
+      try {
+        const gitignoreGlobs = respectGitignore
+          ? await readGitignoreGlobs(folder.uri)
+          : [];
+        const mergedExcludes = Array.from(
+          new Set([...(peekToExclude || []), ...gitignoreGlobs])
+        );
+        file_searches = await Workspace.findFiles(
+          `{${(peekToInclude || []).join(",")}}`,
+          `{${mergedExcludes.join(",")}}`
+        );
+      } catch (err) {
+        // Don't crash the extension host on a transient findFiles failure;
+        // just log and let the next document-open trigger another attempt.
+        sendTelemetryErrorEvent("startClientForFolder", {
+          context: "client",
+          method: "findFiles",
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return;
+      }
       const stylesheets: Stylesheet[] = (
         await mapWithConcurrency(
           file_searches,
@@ -225,8 +237,22 @@ export function activate(context: ExtensionContext): void {
         clientOptions
       );
       client.registerProposedFeatures();
-      client.start();
+
+      // Register the client in `clients` BEFORE calling start() so the
+      // workspace-folder-removed handler can stop it if the folder is
+      // yanked mid-start. If start() throws, undo the registration so the
+      // folder can be retried on the next document-open.
       clients.set(folderKey, client);
+      try {
+        client.start();
+      } catch (err) {
+        clients.delete(folderKey);
+        sendTelemetryErrorEvent("startClientForFolder", {
+          context: "client",
+          method: "client.start",
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
     } finally {
       pendingClientFolders.delete(folderKey);
     }


### PR DESCRIPTION
## Summary

- Closes #154 (150+ `electron-nodejs server.js` processes, ~40-67MB each).
- `didOpenTextDocument` used `!clients.has(folder.uri.toString())` to avoid duplicate spawns, but inserted into `clients` only inside the `.then()` of an async `Workspace.findFiles(...)`. Every document opened between the `findFiles` call and its resolution passed the guard and started a new `LanguageClient` for the same workspace folder. At activation, `Workspace.textDocuments.forEach(didOpenTextDocument)` invokes this synchronously per open document, producing one `server.js` process per supported document — matching the reporter's screenshot.
- Track in-flight client creation in `pendingClientFolders` so concurrent calls coalesce, and clear that set on workspace folder removal so a folder closed mid-`findFiles` doesn't leave a stranded server.

## Test plan

- [x] `yarn build` passes
- [x] `yarn test` passes (24/24)
- [ ] Manual verification: run VS Code with a workspace containing many CSS/SCSS/LESS files (or many files in `peekFromLanguages`) — confirm exactly one `server.js` process is spawned per workspace folder, not one per document. Toggling workspace folders should add/remove processes 1:1.

Manual verification of the leak requires running VS Code for an extended period with workspaces containing many supported documents; there is no autonomous repro in the test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)