### PR TITLE
feat(telemetry): add opt-out setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,22 @@ In addition, it supports the Symbol Provider so you can quickly jump to the righ
 - `cssPeek.supportTags` - Enable Peeking from HTML tags in addition to classnames and IDs. React components are ignored, but it's a good idea to disable this feature when using Angular.
 - `cssPeek.peekFromLanguages` - A list of vscode language names where the extension should be used.
 - `cssPeek.peekToExclude` - A list of file globs that filters out style files to not look for. By default, `node_modules` and `bower_components`
+- `cssPeek.enableTelemetry` - Send anonymous usage data and error reports to help improve CSS Peek. Defaults to `true`. Set to `false` to opt out.
 
 See editor docs for more details
 
 - [Visual Studio Code: Goto Definition](https://code.visualstudio.com/docs/editor/editingevolved#_go-to-definition)
 - [Visual Studio Code: Peek](https://code.visualstudio.com/docs/editor/editingevolved#_peek)
 - [Visual Studio Code: Open Symbol By Name](https://code.visualstudio.com/Docs/editor/editingevolved#_open-symbol-by-name)
+
+## Telemetry
+
+CSS Peek collects anonymous usage data and error reports to help improve the extension. There are **two** ways to opt out:
+
+1. **Disable for this extension only.** Set `"cssPeek.enableTelemetry": false` in your VSCode settings.
+2. **Disable telemetry for all extensions.** Set VSCode's global `"telemetry.telemetryLevel": "off"` (see [VSCode telemetry docs](https://code.visualstudio.com/docs/configure/telemetry)). CSS Peek honors this setting automatically via `@vscode/extension-telemetry`.
+
+Either setting will prevent CSS Peek from sending any telemetry events.
 
 # Contributing
 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -16,13 +16,15 @@ import {
   TransportKind,
 } from "vscode-languageclient/node";
 
-import { initializeReporter } from "./telemetry";
-import TelemetryReporter from "@vscode/extension-telemetry";
+import {
+  initializeReporter,
+  sendTelemetryEvent,
+  sendTelemetryErrorEvent,
+  setTelemetryEnabled,
+} from "./telemetry";
 
 const SUPPORTED_EXTENSIONS = ["css", "scss", "less"];
 const SUPPORTED_EXTENSION_REGEX = /\.(css|scss|less)$/;
-
-let reporter: TelemetryReporter = null;
 
 let defaultClient: LanguageClient;
 const clients: Map<string, LanguageClient> = new Map();
@@ -65,24 +67,38 @@ function getOuterMostWorkspaceFolder(folder: WorkspaceFolder): WorkspaceFolder {
 }
 
 export function activate(context: ExtensionContext): void {
-  reporter = initializeReporter();
+  const config: WorkspaceConfiguration = Workspace.getConfiguration("cssPeek");
+  const telemetryEnabled: boolean = config.get("enableTelemetry", true);
+
+  const reporter = initializeReporter(telemetryEnabled);
   context.subscriptions.push(reporter);
 
-  reporter.sendTelemetryEvent("Activate Extension", { context: "client" });
+  context.subscriptions.push(
+    Workspace.onDidChangeConfiguration((event) => {
+      if (event.affectsConfiguration("cssPeek.enableTelemetry")) {
+        const updated = Workspace.getConfiguration("cssPeek").get(
+          "enableTelemetry",
+          true
+        );
+        setTelemetryEnabled(updated);
+      }
+    })
+  );
+
+  sendTelemetryEvent("Activate Extension", { context: "client" });
 
   const module = context.asAbsolutePath(
     path.join("server", "out", "server.js")
   );
   const outputChannel: OutputChannel = Window.createOutputChannel("CSS Peek");
 
-  const config: WorkspaceConfiguration = Workspace.getConfiguration("cssPeek");
   const peekFromLanguages: Array<string> = config.get(
     "peekFromLanguages"
   ) as Array<string>;
   const peekToInclude = SUPPORTED_EXTENSIONS.map((l) => `**/*.${l}`);
-  const peekToExclude: Array<string> = config.get("peekToExclude") as Array<
-    string
-  >;
+  const peekToExclude: Array<string> = config.get(
+    "peekToExclude"
+  ) as Array<string>;
 
   function didOpenTextDocument(document: TextDocument): void {
     try {
@@ -155,14 +171,14 @@ export function activate(context: ExtensionContext): void {
         );
         defaultClient.registerProposedFeatures();
         defaultClient.start();
-        reporter.sendTelemetryEvent("Document Opened", telemetryData);
+        sendTelemetryEvent("Document Opened", telemetryData);
         return;
       }
       let folder = Workspace.getWorkspaceFolder(uri);
       // Files outside a folder can't be handled. This might depend on the language.
       // Single file languages like JSON might handle files outside the workspace folders.
       if (!folder) {
-        reporter.sendTelemetryEvent("Document Opened", telemetryData);
+        sendTelemetryEvent("Document Opened", telemetryData);
         return;
       }
       // If we have nested workspace folders we only start a server on the outer most workspace folder.
@@ -218,9 +234,9 @@ export function activate(context: ExtensionContext): void {
           clients.set(folder.uri.toString(), client);
         });
       }
-      reporter.sendTelemetryEvent("Document Opened", telemetryData);
+      sendTelemetryEvent("Document Opened", telemetryData);
     } catch (e) {
-      reporter.sendTelemetryErrorEvent(e, {
+      sendTelemetryErrorEvent(e instanceof Error ? e.message : String(e), {
         context: "client",
         method: "didOpenTextDocument",
       });
@@ -233,7 +249,7 @@ export function activate(context: ExtensionContext): void {
     for (const folder of event.removed) {
       const client = clients.get(folder.uri.toString());
       if (client) {
-        reporter.sendTelemetryEvent("Workspace Folder Closed", {
+        sendTelemetryEvent("Workspace Folder Closed", {
           context: "client",
           folderName: folder.name,
           uriAuthority: folder.uri.authority,
@@ -258,7 +274,7 @@ export function deactivate(): Thenable<void> {
   for (const client of clients.values()) {
     promises.push(client.stop());
   }
-  reporter.sendTelemetryEvent(
+  sendTelemetryEvent(
     "Deactivate Extension",
     { context: "client" },
     { activeClients: promises.length }

--- a/client/src/telemetry.ts
+++ b/client/src/telemetry.ts
@@ -2,6 +2,37 @@ import TelemetryReporter from "@vscode/extension-telemetry";
 
 const INSTRUMENTATION_KEY = "7868ce95-465b-4f61-a5f9-99a12abfb3ad";
 
-export function initializeReporter() {
-  return new TelemetryReporter(INSTRUMENTATION_KEY);
+let reporter: TelemetryReporter | null = null;
+let telemetryEnabled = true;
+
+export function initializeReporter(enabled: boolean): TelemetryReporter {
+  telemetryEnabled = enabled;
+  reporter = new TelemetryReporter(INSTRUMENTATION_KEY);
+  return reporter;
+}
+
+export function setTelemetryEnabled(enabled: boolean): void {
+  telemetryEnabled = enabled;
+}
+
+export function sendTelemetryEvent(
+  eventName: string,
+  properties?: Record<string, string>,
+  measurements?: Record<string, number>
+): void {
+  if (!telemetryEnabled || !reporter) {
+    return;
+  }
+  reporter.sendTelemetryEvent(eventName, properties, measurements);
+}
+
+export function sendTelemetryErrorEvent(
+  eventName: string,
+  properties?: Record<string, string>,
+  measurements?: Record<string, number>
+): void {
+  if (!telemetryEnabled || !reporter) {
+    return;
+  }
+  reporter.sendTelemetryErrorEvent(eventName, properties, measurements);
 }

--- a/package.json
+++ b/package.json
@@ -117,6 +117,12 @@
           ],
           "default": "off",
           "description": "Traces the communication between VSCode and the language server."
+        },
+        "cssPeek.enableTelemetry": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "description": "Send anonymous usage data and error reports to help improve CSS Peek. Set to false to opt out. The extension also honors VSCode's global `telemetry.telemetryLevel` setting, so disabling telemetry there will also disable it here."
         }
       }
     }


### PR DESCRIPTION
## Summary

- Add `cssPeek.enableTelemetry` setting (boolean, default `true`) that short-circuits all `sendTelemetryEvent` / `sendTelemetryErrorEvent` calls when disabled.
- Refactor `client/src/telemetry.ts` to expose gated wrappers (`sendTelemetryEvent`, `sendTelemetryErrorEvent`, `setTelemetryEnabled`) and update `client/src/extension.ts` to use them.
- Re-read the setting on `onDidChangeConfiguration` so users do not need to reload.
- Document both opt-out paths (`cssPeek.enableTelemetry` and VSCode's global `telemetry.telemetryLevel`) in `README.md`.

Closes #140

## Test plan

- [x] `yarn build` compiles with zero TS errors
- [x] `yarn test` — all 24 existing tests still pass
- [x] `yarn lint` clean
- [x] Verified the wrapper short-circuits when the setting is `false`: `sendTelemetryEvent` and `sendTelemetryErrorEvent` return early without calling the underlying reporter.
- [ ] Manually toggle `cssPeek.enableTelemetry` in VSCode settings and confirm no events fire after the change (no reload required).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>