### PR TITLE
feat: peek into <style> blocks in HTML/Vue files (#151)

### DIFF
--- a/server/src/core/embeddedStyles.ts
+++ b/server/src/core/embeddedStyles.ts
@@ -1,0 +1,136 @@
+import { TextDocument } from "vscode-languageserver-textdocument";
+import {
+  Scanner,
+  getLanguageService as getHTMLLanguageService,
+  TokenType,
+} from "vscode-html-languageservice";
+
+import { StylesheetMap } from "../types";
+
+/**
+ * Determines whether a source document may contain embedded `<style>` blocks
+ * that this extension should also search for definitions.
+ */
+export function hasEmbeddedStyles(languageId: string): boolean {
+  return languageId === "html" || languageId === "vue";
+}
+
+/**
+ * Map a `<style lang="...">` attribute value to a language id our CSS
+ * language services understand. Anything we don't recognise falls back to
+ * plain CSS.
+ */
+function languageIdFromLangAttr(lang: string | null): string {
+  if (!lang) return "css";
+  const normalised = lang.toLowerCase();
+  switch (normalised) {
+    case "scss":
+    case "sass":
+      return "scss";
+    case "less":
+      return "less";
+    case "css":
+    case "postcss":
+      return "css";
+    default:
+      return "css";
+  }
+}
+
+/**
+ * Replace every character of `source` outside of `[start, end)` with a space,
+ * preserving newline characters so that line/column positions for content
+ * within the embedded region match the parent document exactly.
+ */
+function maskOutside(source: string, start: number, end: number): string {
+  // Only the *outside* regions need masking; the inner [start, end) slice is
+  // copied verbatim. We mask each outside region with a single regex pass to
+  // avoid per-character string concatenation.
+  const mask = (s: string) => s.replace(/[^\n\r]/g, " ");
+  return (
+    mask(source.slice(0, start)) +
+    source.slice(start, end) +
+    mask(source.slice(end))
+  );
+}
+
+/**
+ * Extract every embedded `<style>` block in an HTML/Vue document and return a
+ * `StylesheetMap` of virtual documents whose offsets match the host document.
+ *
+ * Each entry's URI carries a `#style-<index>` fragment so the cache key is
+ * unique per block but still tied back to the host document URI.
+ */
+export function extractEmbeddedStylesheets(
+  document: TextDocument
+): StylesheetMap {
+  if (!hasEmbeddedStyles(document.languageId)) {
+    return {};
+  }
+
+  const text = document.getText();
+  const scanner: Scanner = getHTMLLanguageService().createScanner(text);
+  const result: StylesheetMap = {};
+
+  let inStyleTag = false;
+  let currentAttribute: string | null = null;
+  let currentLang: string | null = null;
+  let blockIndex = 0;
+
+  let tokenType = scanner.scan();
+  while (tokenType !== TokenType.EOS) {
+    switch (tokenType) {
+      case TokenType.StartTag: {
+        const tagName = scanner.getTokenText().toLowerCase();
+        inStyleTag = tagName === "style";
+        currentAttribute = null;
+        currentLang = null;
+        break;
+      }
+      case TokenType.AttributeName: {
+        currentAttribute = scanner.getTokenText().toLowerCase();
+        break;
+      }
+      case TokenType.AttributeValue: {
+        if (inStyleTag && currentAttribute === "lang") {
+          // Strip surrounding quotes if present.
+          const raw = scanner.getTokenText();
+          currentLang = raw.replace(/^['"]|['"]$/g, "");
+        }
+        currentAttribute = null;
+        break;
+      }
+      case TokenType.Styles: {
+        if (!inStyleTag) break;
+        const start = scanner.getTokenOffset();
+        const end = scanner.getTokenEnd();
+        const languageId = languageIdFromLangAttr(currentLang);
+        const maskedText = maskOutside(text, start, end);
+        // Use the host document URI on the embedded TextDocument so the
+        // resulting SymbolInformation locations point back at the host file
+        // (this is what makes peek/goto jump to the embedded `<style>` block
+        // in the original document). The map key includes a fragment so the
+        // cache slot stays distinct from the host's own entry (and from other
+        // `<style>` blocks in the same document).
+        const cacheKey = `${document.uri}#style-${blockIndex++}`;
+        const embeddedDoc = TextDocument.create(
+          document.uri,
+          languageId,
+          document.version,
+          maskedText
+        );
+        result[cacheKey] = { document: embeddedDoc };
+        break;
+      }
+      case TokenType.EndTag: {
+        inStyleTag = false;
+        currentAttribute = null;
+        currentLang = null;
+        break;
+      }
+    }
+    tokenType = scanner.scan();
+  }
+
+  return result;
+}

--- a/server/src/core/findDefinition.ts
+++ b/server/src/core/findDefinition.ts
@@ -55,10 +55,22 @@ function resolveSymbolName(symbols: SymbolInformation[], i: number): string {
 export function findSymbols(
   selector: Selector,
   stylesheetMap: StylesheetMap,
-  options: { peekVariables?: boolean } = {}
+  options: {
+    peekVariables?: boolean;
+    embeddedStylesheetMap?: StylesheetMap;
+  } = {}
 ): SymbolInformation[] {
-  const { peekVariables = true } = options;
+  const { peekVariables = true, embeddedStylesheetMap = {} } = options;
   const foundSymbols: SymbolInformation[] = [];
+
+  // Merge the persistent stylesheet cache with any in-memory embedded
+  // stylesheets (e.g. `<style>` blocks in HTML/Vue). The persistent cache
+  // wins on key collision; embedded entries always use fragment-suffixed
+  // keys so collisions don't happen in practice.
+  const combinedMap: StylesheetMap = {
+    ...embeddedStylesheetMap,
+    ...stylesheetMap,
+  };
 
   // Construct RegExp of selector to test against the symbols
   let selection = getSelection(selector);
@@ -84,8 +96,8 @@ export function findSymbols(
   const fileRegexp = new RegExp(selection, classOrIdSelector ? "" : "i");
 
   // Test all the symbols against the RegExp
-  Object.keys(stylesheetMap).forEach((uri) => {
-    const styleSheet = stylesheetMap[uri];
+  Object.keys(combinedMap).forEach((uri) => {
+    const styleSheet = combinedMap[uri];
     try {
       let symbols: SymbolInformation[];
       if (styleSheet.symbols) {
@@ -147,7 +159,10 @@ export function findSymbols(
 export function findDefinition(
   selector: Selector,
   stylesheetMap: StylesheetMap,
-  options: { peekVariables?: boolean } = {}
+  options: {
+    peekVariables?: boolean;
+    embeddedStylesheetMap?: StylesheetMap;
+  } = {}
 ): Location[] {
   return findSymbols(selector, stylesheetMap, options).map(
     ({ location }) => location

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -24,6 +24,10 @@ import {
   isLanguageServiceSupported,
 } from "./core/findDefinition";
 import { findHover } from "./core/findHover";
+import {
+  extractEmbeddedStylesheets,
+  hasEmbeddedStyles,
+} from "./core/embeddedStyles";
 import { create } from "./logger";
 
 // Creates the LSP connection
@@ -230,8 +234,16 @@ connection.onDefinition(
       return null;
     }
 
+    // For HTML/Vue source documents, also search any embedded `<style>`
+    // blocks within the same file. We parse these on-demand rather than
+    // caching, since their content is tightly coupled to the host doc.
+    const embeddedStylesheetMap = hasEmbeddedStyles(document.languageId)
+      ? extractEmbeddedStylesheets(document)
+      : {};
+
     return findDefinition(selector, styleSheets, {
       peekVariables: settings.peekVariables,
+      embeddedStylesheetMap,
     });
   }
 );

--- a/tests/fixture/example.html
+++ b/tests/fixture/example.html
@@ -1,5 +1,14 @@
 <html>
-  <head> </head>
+  <head>
+    <style>
+      .embedded-class {
+        color: red;
+      }
+      #embedded-id {
+        background: yellow;
+      }
+    </style>
+  </head>
   <body>
     <h1 class="test common" id="testID common">heading</h1>
     <div class="container">
@@ -9,6 +18,8 @@
       <span class="test-3"></span>
       <span class="test-4"></span>
       <span class="class45870"></span>
+      <span class="embedded-class"></span>
+      <span id="embedded-id"></span>
     </div>
   </body>
 </html>

--- a/tests/src/findDefinition.test.ts
+++ b/tests/src/findDefinition.test.ts
@@ -10,6 +10,7 @@ import {
   findDefinition,
   findSymbols,
 } from "../../server/out/core/findDefinition";
+import { extractEmbeddedStylesheets } from "../../server/out/core/embeddedStyles";
 import { create } from "../../server/out/logger";
 import type { StylesheetMap, Selector } from "../../server/src/types";
 
@@ -130,5 +131,67 @@ suite("findDefinition", () => {
       defs.length > 0,
       "class selectors should still resolve when peekVariables=false"
     );
+  });
+});
+
+suite("findDefinition with embedded <style> blocks", () => {
+  create(console as any);
+
+  async function loadHostDoc(file: string) {
+    const vscodeDoc = await vscode.workspace.openTextDocument(
+      vscode.Uri.joinPath(vscode.workspace.workspaceFolders![0].uri, file)
+    );
+    return ServerTextDocument.create(
+      vscodeDoc.uri.toString(),
+      vscodeDoc.languageId,
+      vscodeDoc.version,
+      vscodeDoc.getText()
+    );
+  }
+
+  test("finds class defined in a <style> block of the same HTML file", async () => {
+    const hostDoc = await loadHostDoc("example.html");
+    const embedded = extractEmbeddedStylesheets(hostDoc);
+    assert.ok(Object.keys(embedded).length > 0, "should find a <style> block");
+
+    const selector: Selector = { attribute: "class", value: "embedded-class" };
+    const defs = findDefinition(selector, {}, { embeddedStylesheetMap: embedded });
+
+    assert.strictEqual(defs.length, 1);
+    // The returned location should reference the host HTML file (peek
+    // navigates the user to the embedded <style> region in the original
+    // file, not to some synthetic URI).
+    assert.strictEqual(defs[0].uri, hostDoc.uri);
+
+    // Verify the location points at the actual `.embedded-class` rule by
+    // grabbing the slice of host text at the returned range.
+    const text = hostDoc.getText();
+    const startOffset = hostDoc.offsetAt(defs[0].range.start);
+    assert.ok(
+      text.slice(startOffset).startsWith(".embedded-class"),
+      `expected text at definition to start with ".embedded-class", got: ${text.slice(
+        startOffset,
+        startOffset + 40
+      )}`
+    );
+  });
+
+  test("finds id defined in a <style> block of the same HTML file", async () => {
+    const hostDoc = await loadHostDoc("example.html");
+    const embedded = extractEmbeddedStylesheets(hostDoc);
+
+    const selector: Selector = { attribute: "id", value: "embedded-id" };
+    const defs = findDefinition(selector, {}, { embeddedStylesheetMap: embedded });
+
+    assert.strictEqual(defs.length, 1);
+    assert.strictEqual(defs[0].uri, hostDoc.uri);
+    const startOffset = hostDoc.offsetAt(defs[0].range.start);
+    assert.ok(hostDoc.getText().slice(startOffset).startsWith("#embedded-id"));
+  });
+
+  test("returns nothing for non-html/vue documents", async () => {
+    const cssDoc = await loadHostDoc("stylesheet.css");
+    const embedded = extractEmbeddedStylesheets(cssDoc);
+    assert.deepStrictEqual(embedded, {});
   });
 });


### PR DESCRIPTION
## Summary

Closes #151

Adds same-file CSS support: when peeking from a `class="..."`, `id="..."`, or HTML tag in an HTML or Vue document, the extension now also resolves selectors defined in any `<style>` block within the same file.

- New `server/src/core/embeddedStyles.ts` uses `vscode-html-languageservice`'s scanner (already a dep) to locate `<style>` regions and reads any `lang="scss|sass|less"` attribute to pick the right CSS parser.
- The embedded virtual `TextDocument` reuses the host document's URI and masks everything outside the `<style>` region with whitespace (preserving newlines), so symbol positions line up exactly with the host file — peek/goto jumps to the correct line without any coordinate translation.
- `findSymbols`/`findDefinition` accept an optional in-memory `embeddedStylesheetMap` that's merged with the persistent `StylesheetMap`. The persistent cache wins on key collision; embedded entries use fragment-suffixed keys so collisions don't happen in practice.
- Only runs for `html` and `vue` documents — JS/TS/etc. peek paths are unchanged.

## Test plan

- [x] `yarn build` passes with zero TS errors
- [x] `yarn lint` passes
- [x] `yarn test` — 27 tests pass, including three new cases:
  - class defined in `<style>` block is found in the same HTML file
  - id defined in `<style>` block is found in the same HTML file
  - non-HTML/Vue documents yield no embedded stylesheets
- [x] Fixture `tests/fixture/example.html` updated with a `<style>` block containing `.embedded-class` and `#embedded-id` plus matching usages in the body

🤖 Generated with [Claude Code](https://claude.com/claude-code)