### PR TITLE
feat(client): respect .gitignore + better exclude defaults (#145)

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -22,6 +22,7 @@ import {
   sendTelemetryErrorEvent,
   setTelemetryEnabled,
 } from "./telemetry";
+import { readGitignoreGlobs } from "./gitignore";
 
 const SUPPORTED_EXTENSIONS = ["css", "scss", "less"];
 const SUPPORTED_EXTENSION_REGEX = /\.(css|scss|less)$/;
@@ -103,6 +104,7 @@ export function activate(context: ExtensionContext): void {
     "peekToLinkedOnly",
     false
   ) as boolean;
+  const respectGitignore: boolean = config.get("respectGitignore") as boolean;
 
   function didOpenTextDocument(document: TextDocument): void {
     try {
@@ -191,54 +193,65 @@ export function activate(context: ExtensionContext): void {
       telemetryData.workspaceFolder = folder;
 
       if (!clients.has(folder.uri.toString())) {
-        Workspace.findFiles(
-          `{${(peekToInclude || []).join(",")}}`,
-          `{${(peekToExclude || []).join(",")}}`
-        ).then((file_searches) => {
-          const potentialFiles: Uri[] = file_searches.filter(
-            (uri: Uri) => uri.scheme === "file"
-          );
+        const gitignorePromise = respectGitignore
+          ? readGitignoreGlobs(folder.uri)
+          : Promise.resolve([] as string[]);
 
-          const debugOptions = {
-            execArgv: ["--nolazy", `--inspect=${6011 + clients.size}`],
-          };
-          const serverOptions = {
-            run: { module, transport: TransportKind.ipc },
-            debug: {
-              module,
-              transport: TransportKind.ipc,
-              options: debugOptions,
-            },
-          };
-          const clientOptions: LanguageClientOptions = {
-            documentSelector,
-            diagnosticCollectionName: "css-peek",
-            synchronize: {
-              configurationSection: "cssPeek",
-            },
-            initializationOptions: {
-              stylesheets: potentialFiles.map((u) => ({
-                uri: u.toString(),
-                // TODO: don't rely on fsPath in a virtual workspace
-                // https://github.com/microsoft/vscode/wiki/Virtual-Workspaces
-                fsPath: u.fsPath,
-              })),
-              peekFromLanguages,
-              peekToLinkedOnly,
-            },
-            workspaceFolder: folder,
-            outputChannel,
-          };
-          const client = new LanguageClient(
-            "css-peek",
-            "CSS Peek",
-            serverOptions,
-            clientOptions
-          );
-          client.registerProposedFeatures();
-          client.start();
-          clients.set(folder.uri.toString(), client);
-        });
+        gitignorePromise
+          .then((gitignoreGlobs) => {
+            const mergedExcludes = Array.from(
+              new Set([...(peekToExclude || []), ...gitignoreGlobs])
+            );
+            return Workspace.findFiles(
+              `{${(peekToInclude || []).join(",")}}`,
+              `{${mergedExcludes.join(",")}}`
+            );
+          })
+          .then((file_searches) => {
+            const potentialFiles: Uri[] = file_searches.filter(
+              (uri: Uri) => uri.scheme === "file"
+            );
+
+            const debugOptions = {
+              execArgv: ["--nolazy", `--inspect=${6011 + clients.size}`],
+            };
+            const serverOptions = {
+              run: { module, transport: TransportKind.ipc },
+              debug: {
+                module,
+                transport: TransportKind.ipc,
+                options: debugOptions,
+              },
+            };
+            const clientOptions: LanguageClientOptions = {
+              documentSelector,
+              diagnosticCollectionName: "css-peek",
+              synchronize: {
+                configurationSection: "cssPeek",
+              },
+              initializationOptions: {
+                stylesheets: potentialFiles.map((u) => ({
+                  uri: u.toString(),
+                  // TODO: don't rely on fsPath in a virtual workspace
+                  // https://github.com/microsoft/vscode/wiki/Virtual-Workspaces
+                  fsPath: u.fsPath,
+                })),
+                peekFromLanguages,
+                peekToLinkedOnly,
+              },
+              workspaceFolder: folder,
+              outputChannel,
+            };
+            const client = new LanguageClient(
+              "css-peek",
+              "CSS Peek",
+              serverOptions,
+              clientOptions
+            );
+            client.registerProposedFeatures();
+            client.start();
+            clients.set(folder.uri.toString(), client);
+          });
       }
       sendTelemetryEvent("Document Opened", telemetryData);
     } catch (e) {

--- a/client/src/gitignore.ts
+++ b/client/src/gitignore.ts
@@ -4,15 +4,27 @@ import { workspace as Workspace, Uri } from "vscode";
  * Convert a single `.gitignore` pattern line into one or more VS Code glob
  * patterns.
  *
- * Returns an empty array for lines that should be skipped (blank, comment,
- * negation, or patterns we can't represent as a simple glob).
+ * Lines explicitly skipped (returns an empty array):
+ *   - blank lines (after trimming)
+ *   - comments (lines starting with `#`)
+ *   - negation lines (lines starting with `!`)
+ *   - lines that reduce to an empty pattern after stripping a leading `/`
+ *     or trailing `/`
  *
- * Best-effort conversion covering common cases (directory names, file names,
- * simple globs). When the line could match either a file or a directory, we
- * emit both globs since VS Code globs distinguish files from folders.
+ * All other lines are passed through with minimal rewriting (anchoring,
+ * directory-vs-file expansion, bare-name -> `**\/name` lift). This is a
+ * best-effort conversion covering the common cases (directory names, file
+ * names, simple `*` globs). When the line could match either a file or a
+ * directory, we emit both globs since VS Code globs distinguish files from
+ * folders.
  *
- * Known limitations: negation lines (`!pattern`), character classes, and
- * patterns with `**` semantics that differ from gitignore are not handled.
+ * Unsupported gitignore constructs are NOT detected — they are passed
+ * through verbatim and may produce wrong or best-effort matches:
+ *   - character classes (e.g. `[abc]`, `[!a-z]`)
+ *   - escape sequences (`\#`, `\!`, `\ `)
+ *   - `**` in positions where gitignore semantics differ from VS Code's
+ *     glob semantics (common shapes like `foo/**` and `**\/foo` work;
+ *     exotic placements may not)
  */
 export function gitignoreLineToGlob(rawLine: string): string[] {
   const line = rawLine.trim();
@@ -53,8 +65,11 @@ export function gitignoreLineToGlob(rawLine: string): string[] {
  * Read the workspace root's `.gitignore` and return a set of VS Code glob
  * patterns that approximate its semantics.
  *
- * Uses `vscode.workspace.fs` so it works in virtual workspaces. Returns an
- * empty array if the file does not exist or cannot be read.
+ * Uses `vscode.workspace.fs` (rather than Node `fs`) so the reader itself
+ * is not tied to local disk. Note: the extension as a whole does not yet
+ * declare virtual-workspace support — see `capabilities.virtualWorkspaces`
+ * in `package.json` and the server's direct `fs` usage. Returns an empty
+ * array if the file does not exist or cannot be read.
  */
 export async function readGitignoreGlobs(
   workspaceRoot: Uri

--- a/client/src/gitignore.ts
+++ b/client/src/gitignore.ts
@@ -1,0 +1,79 @@
+import { workspace as Workspace, Uri } from "vscode";
+
+/**
+ * Convert a single `.gitignore` pattern line into one or more VS Code glob
+ * patterns.
+ *
+ * Returns an empty array for lines that should be skipped (blank, comment,
+ * negation, or patterns we can't represent as a simple glob).
+ *
+ * Best-effort conversion covering common cases (directory names, file names,
+ * simple globs). When the line could match either a file or a directory, we
+ * emit both globs since VS Code globs distinguish files from folders.
+ *
+ * Known limitations: negation lines (`!pattern`), character classes, and
+ * patterns with `**` semantics that differ from gitignore are not handled.
+ */
+export function gitignoreLineToGlob(rawLine: string): string[] {
+  const line = rawLine.trim();
+
+  if (line.length === 0 || line.startsWith("#") || line.startsWith("!")) {
+    return [];
+  }
+
+  let pattern = line;
+
+  const isDirectoryPattern = pattern.endsWith("/");
+  if (isDirectoryPattern) {
+    pattern = pattern.slice(0, -1);
+  }
+
+  const isAnchored = pattern.startsWith("/");
+  if (isAnchored) {
+    pattern = pattern.slice(1);
+  }
+
+  if (pattern.length === 0) {
+    return [];
+  }
+
+  // Patterns with a slash are workspace-root-relative; bare names match
+  // anywhere in the tree.
+  const base = isAnchored || pattern.includes("/") ? pattern : `**/${pattern}`;
+
+  // A directory marker (`foo/`) only matches the directory and its contents.
+  // Without it, gitignore matches both files and directories — emit both.
+  if (isDirectoryPattern) {
+    return [`${base}/**`];
+  }
+  return [base, `${base}/**`];
+}
+
+/**
+ * Read the workspace root's `.gitignore` and return a set of VS Code glob
+ * patterns that approximate its semantics.
+ *
+ * Uses `vscode.workspace.fs` so it works in virtual workspaces. Returns an
+ * empty array if the file does not exist or cannot be read.
+ */
+export async function readGitignoreGlobs(
+  workspaceRoot: Uri
+): Promise<string[]> {
+  const gitignoreUri = Uri.joinPath(workspaceRoot, ".gitignore");
+
+  let bytes: Uint8Array;
+  try {
+    bytes = await Workspace.fs.readFile(gitignoreUri);
+  } catch {
+    return [];
+  }
+
+  const content = Buffer.from(bytes).toString("utf-8");
+  const globs = new Set<string>();
+  for (const line of content.split(/\r?\n/)) {
+    for (const glob of gitignoreLineToGlob(line)) {
+      globs.add(glob);
+    }
+  }
+  return Array.from(globs);
+}

--- a/package.json
+++ b/package.json
@@ -106,7 +106,13 @@
           "type": "array",
           "default": [
             "**/node_modules/**",
-            "**/bower_components/**"
+            "**/bower_components/**",
+            "**/.git/**",
+            "**/dist/**",
+            "**/build/**",
+            "**/.next/**",
+            "**/out/**",
+            "**/coverage/**"
           ],
           "items": {
             "type": "string"
@@ -118,6 +124,12 @@
           "type": "boolean",
           "default": false,
           "description": "When enabled, peek targets are restricted to stylesheets that are referenced from the current source file (e.g. via <link rel=\"stylesheet\" href=\"...\"> in HTML or `import './foo.css'` / `@import 'foo.css'` in JS/TS/SCSS). Useful in large monorepos to avoid matching unrelated stylesheets."
+        },
+        "cssPeek.respectGitignore": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "description": "When enabled, patterns from the workspace root's .gitignore are merged into cssPeek.peekToExclude so peek does not match files Git ignores. Negation (!pattern) lines and nested .gitignore files are not supported."
         },
         "cssPeek.trace.server": {
           "scope": "window",

--- a/tests/fixture/.gitignore
+++ b/tests/fixture/.gitignore
@@ -1,0 +1,7 @@
+# Fixture .gitignore used by gitignore.test.ts to verify
+# that readGitignoreGlobs parses a workspace-root .gitignore.
+# These paths intentionally do not match any real fixture file.
+excluded.css
+/anchored-build
+dist/
+!unignore.css

--- a/tests/src/gitignore.test.ts
+++ b/tests/src/gitignore.test.ts
@@ -1,0 +1,83 @@
+import * as assert from "assert";
+import * as path from "path";
+import * as vscode from "vscode";
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const gitignoreMod = require("../../client/out/gitignore") as {
+  gitignoreLineToGlob: (line: string) => string[];
+  readGitignoreGlobs: (uri: vscode.Uri) => Promise<string[]>;
+};
+const { gitignoreLineToGlob, readGitignoreGlobs } = gitignoreMod;
+
+suite("gitignoreLineToGlob", () => {
+  test("skips blank lines and comments", () => {
+    assert.deepStrictEqual(gitignoreLineToGlob(""), []);
+    assert.deepStrictEqual(gitignoreLineToGlob("   "), []);
+    assert.deepStrictEqual(gitignoreLineToGlob("# comment"), []);
+  });
+
+  test("skips negation lines", () => {
+    assert.deepStrictEqual(gitignoreLineToGlob("!keep.css"), []);
+  });
+
+  test("unanchored bare names match both files and directories anywhere", () => {
+    assert.deepStrictEqual(gitignoreLineToGlob("node_modules"), [
+      "**/node_modules",
+      "**/node_modules/**",
+    ]);
+    assert.deepStrictEqual(gitignoreLineToGlob("excluded.css"), [
+      "**/excluded.css",
+      "**/excluded.css/**",
+    ]);
+  });
+
+  test("trailing slash matches directories only", () => {
+    assert.deepStrictEqual(gitignoreLineToGlob("dist/"), ["**/dist/**"]);
+  });
+
+  test("leading slash anchors to workspace root", () => {
+    assert.deepStrictEqual(gitignoreLineToGlob("/build"), [
+      "build",
+      "build/**",
+    ]);
+    assert.deepStrictEqual(gitignoreLineToGlob("/build/"), ["build/**"]);
+  });
+
+  test("nested paths are relative to workspace root", () => {
+    assert.deepStrictEqual(gitignoreLineToGlob("packages/foo/dist"), [
+      "packages/foo/dist",
+      "packages/foo/dist/**",
+    ]);
+  });
+
+  test("trims whitespace", () => {
+    assert.deepStrictEqual(gitignoreLineToGlob("  coverage  "), [
+      "**/coverage",
+      "**/coverage/**",
+    ]);
+  });
+});
+
+suite("readGitignoreGlobs", () => {
+  test("returns empty array when .gitignore is missing", async () => {
+    const tmpRoot = vscode.Uri.file(
+      path.join(__dirname, `__missing_gitignore_${Date.now()}`)
+    );
+    const globs = await readGitignoreGlobs(tmpRoot);
+    assert.deepStrictEqual(globs, []);
+  });
+
+  test("parses .gitignore from the workspace root", async () => {
+    const root = vscode.workspace.workspaceFolders![0].uri;
+    const globs = await readGitignoreGlobs(root);
+    // .gitignore in the test fixture contains `excluded.css`.
+    assert.ok(
+      globs.includes("**/excluded.css"),
+      `expected file glob; got ${JSON.stringify(globs)}`
+    );
+    assert.ok(
+      globs.includes("**/excluded.css/**"),
+      `expected dir glob; got ${JSON.stringify(globs)}`
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Add a new `cssPeek.respectGitignore` setting (default `true`) that reads the workspace root `.gitignore` and merges its patterns into `cssPeek.peekToExclude` before calling `Workspace.findFiles`.
- Expand the default `cssPeek.peekToExclude` to also cover common build artifact directories: `**/.git/**`, `**/dist/**`, `**/build/**`, `**/.next/**`, `**/out/**`, `**/coverage/**`.
- Reads `.gitignore` via `vscode.workspace.fs.readFile` (no new Node `fs` dependency added on the client). Note: the extension as a whole does not yet declare virtual-workspace support — `package.json` still has `capabilities.virtualWorkspaces.supported: false` and the language server uses Node `fs`. This PR does not change that; it just keeps the new reader from being the blocker if/when the rest of the extension catches up.
- No new npm dependencies — a small line-based `.gitignore` -> glob converter lives in `client/src/gitignore.ts`.

Closes #145

## Behavior

When `cssPeek.respectGitignore` is `true`:
1. The extension reads the `.gitignore` at the workspace root (if any).
2. Each non-empty, non-comment, non-negation line is converted to one or two VS Code globs (file + directory variants for bare names; directory-only when the line ends with `/`).
3. Those globs are deduped against `cssPeek.peekToExclude` and passed as the exclude pattern to `Workspace.findFiles`.

## Known limitations / edge cases

The converter is small and dependency-free. It explicitly skips:
- Blank lines and comments (`#...`)
- Negation lines (`!pattern`) — skipped to avoid accidentally including files
- Patterns that reduce to empty after stripping a leading `/` or trailing `/`
- Nested `.gitignore` files in subdirectories (only the workspace root file is read)

Other unsupported gitignore constructs are NOT detected — they pass through verbatim and may produce wrong or best-effort matches:
- Character classes (`[abc]`, `[!a-z]`)
- Escape sequences (`\#`, `\!`, `\ `)
- `**` placements where gitignore semantics differ from VS Code's glob semantics — common shapes (`foo/**`, `**/foo`) work, exotic ones may not

Users with complex ignore needs can set `cssPeek.respectGitignore` to `false` and manage `cssPeek.peekToExclude` directly.

## Test plan

- [x] `yarn build` — zero TS errors
- [x] `yarn test` — 33 passing (8 new tests covering `gitignoreLineToGlob` + `readGitignoreGlobs` with a fixture `.gitignore`)
- [x] `yarn lint` — clean
- [ ] Manual smoke: open a real project with `dist/` containing a duplicate stylesheet and verify peek navigates to the source file, not the built copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)