### PR TITLE
ci: add Windows runner to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:
@@ -41,6 +41,6 @@ jobs:
         if: runner.os == 'Linux'
         run: xvfb-run -a yarn test
 
-      - name: Test (macOS)
-        if: runner.os == 'macOS'
+      - name: Test (macOS / Windows)
+        if: runner.os != 'Linux'
         run: yarn test


### PR DESCRIPTION
Adds windows-latest alongside Ubuntu/macOS. VSCode runs on Windows in production and posix-only assumptions in path handling or postinstall can drift silently — this catches them at CI time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)